### PR TITLE
sécurisation des formulaires

### DIFF
--- a/src/Controller/ModificationPieceController.php
+++ b/src/Controller/ModificationPieceController.php
@@ -18,10 +18,11 @@ class ModificationPieceController extends AbstractController
             $category = $_GET['category']; // FETCHED from listPiece.php "catResults" => Component::AVAILABLE_CATEGORIES,
 
             if (isset($_POST['name']) && isset($_POST['brand']) && isset($_POST['description']) && isset($_POST['price']) && isset($_POST['componentType'])) {  // the value of URL from modify button is initialised to take the new values from the form $_POST
-                $name = $_POST['name'];
-                $brand = $_POST['brand'];
-                $description = $_POST['description'];
-                $price = $_POST['price'];
+                // Filtrage des caractères spéciaux : La fonction htmlspecialchars() permet d'échapper les caractères spéciaux potentiellement dangereux tels que les balises HTML
+                $name = htmlspecialchars($_POST['name']);
+                $brand = htmlspecialchars($_POST['brand']);
+                $description = htmlspecialchars($_POST['description']);
+                $price = htmlspecialchars($_POST['price']);
                 $componentType = $_POST['componentType'];
 
                 $sqlComponent = "UPDATE component

--- a/src/Service/ModelHandler.php
+++ b/src/Service/ModelHandler.php
@@ -39,7 +39,8 @@ class ModelHandler
     {
         $complete = true;
         if (isset($postData['name'])) {
-            $this->setName($postData['name']);
+            // Filtrage des caractères spéciaux : La fonction htmlspecialchars() permet d'échapper les caractères spéciaux potentiellement dangereux tels que les balises HTML
+            $this->setName(htmlspecialchars($postData['name']));
             $this->isSubmitted = true;
         } else {
             $complete = false;
@@ -51,7 +52,8 @@ class ModelHandler
             $complete = false;
         }
         if (isset($postData['description'])) {
-            $this->setDescriptionModel($postData['description']);
+            // Filtrage des caractères spéciaux : La fonction htmlspecialchars() permet d'échapper les caractères spéciaux potentiellement dangereux tels que les balises HTML
+            $this->setDescriptionModel(htmlspecialchars($postData['description']));
             $this->isSubmitted = true;
         }
         if (isset($postData['Modeltype'])) {


### PR DESCRIPTION
Utilisation de la fonction htmlspecialchars() pour échapper les balises HTML dans les formulaires. Cela évite qu'un utilisateur mal intentionné ne s'amuse à insérer du JS dans les noms ou descriptions des modèles. Par exemple ```<script> Vive les nouilles("Trollage"); </script>```